### PR TITLE
Move lesson from Java modules to here

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,32 +1,82 @@
-# Testing Pyramid
+# The Testing Pyramid
 
 ## Learning Goals
 
-- Learning Goal 1
-- Learning Goal 2
+- Review and understand different types of testing.
+- Describe the testing pyramid.
 
-## Introduction
+## Review Types of Testing
 
-A 1-2 sentence summary of what will be covered.
+Let's review some different types of testing:
 
-## Topic 1
+### Unit Testing
 
-Discuss the topic of the reading. Break into sections and sub-sections as
-appropriate to help with the reader's orientation with the material and future
-referencing.
+**Unit testing** is a specific kind of testing that focuses on validating the
+functionality of a single component of the system. It tests a small, specific
+piece of functionality.
 
-## Topic 2
+### Integration Testing
 
-Discuss the topic of the reading. Break into sections and sub-sections as
-appropriate to help with the reader's orientation with the material and future
-referencing.
+**Integration testing** is a type of testing that looks at multiple components of
+a program and tests how well these modules may work together. The components
+that are involved in integration testing are usually unit tested already with a
+goal to see if any issues are exposed when they are integrated together. This
+phase of testing will start to bring in some Spring framework functionality.
+
+Also, another type of functional testing that goes hand-in-hand with integration
+testing is **acceptance testing**. Acceptance testing is the last phase of
+functional testing and will ensure that all the layers of an API are tested and
+functions the way it is expected by the end users.
+
+### User Interface (UI) Testing
+
+**User Interface (UI) testing** consists of testing the interface that users
+interact with. UI tests need to cover the components of the system that are
+responsible for presenting the information to actual end users and getting
+information from those users. For example, testing the functionality and
+features on a website. This could include looking at menus, images, and links.
+
+### Manual Testing
+
+Manual testing is the process of testing the system manually. An example of this
+type of testing is when we would use print statements to verify if our code was
+working properly.
+
+## Testing Pyramid
+
+A **testing pyramid** is a metaphor that can help developers and other types of
+testers understand how to test. By that, we mean to answer the following
+questions:
+
+- How many tests are needed?
+- How frequently should we run these tests?
+
+The testing pyramid looks at the four types of tests we identified above to
+answer these questions:
+
+![testing-pyramid.jpeg](https://curriculum-content.s3.amazonaws.com/java-mod-3/testing-pyramid.jpeg)
+
+While not all types of testing will be created or maintained by developers, it's
+important that we understand the basic principles of the testing pyramid because
+unit testing is the foundation on which all other types of testing are built,
+and a pyramid can only be as strong as its foundation.
+
+The principles of the testing pyramid can be summarized as follows:
+
+1. The more automated and faster the tests are to run, the more permutations of
+   possible use case they should cover, and the more frequently they should be
+   run.
+2. Conversely, the slower the tests are to run, the higher the level of
+   functionality they cover (i.e. the more components the functionality requires
+   to come together), the less permutations they should cover, and the less
+   frequently they should run.
 
 ## Conclusion
 
-A short one or two paragraph summary of the contents of the lessons, recapping
-the learning goals.
+Now that our codebase is a little more complex having added the Spring Framework
+and its dependencies, we'll be focusing on other aspects of the testing pyramid
+than we were before. Previously, we were just creating JUnit tests for our Java
+code. But now, in addition to unit testing, we will also focus on integration
+and acceptance testing within the Spring Framework.
 
-## Resources
-
-- [Resource Link 1](example.com)
-- [Resource Link 2](example.com)
+Let's revisit unit testing in the next lesson.


### PR DESCRIPTION
This change is being made in the consumer canvas per the conversation on 7/22 to keep the same modules for Blackrock and AWS to streamline.

This lesson has been moved / will be removed from the Java modules to here since we'll talk more about integration testing when it comes to Spring. This should provide a review of testing, introducing potentially new terms, and introducing the concept of the testing pyramid.